### PR TITLE
Call parent sendMessage instead of send

### DIFF
--- a/Model/Transport.php
+++ b/Model/Transport.php
@@ -222,7 +222,7 @@ class Transport extends \Magento\Framework\Mail\Transport implements TransportIn
 			}
 		} else {
 			$this->_logger->debug('[Flowmailer] Module not enabled');
-			parent::send($this->_message);
+			parent::sendMessage($this->_message);
 		}
 	}
 


### PR DESCRIPTION
If the Flowmailer module is not enabled, the wrong fallback method is being called in Magento.