### PR TITLE
Fix typo

### DIFF
--- a/Helper/API/Attachment.php
+++ b/Helper/API/Attachment.php
@@ -1,10 +1,12 @@
 <?php
 namespace Flowmailer\M2Connector\Helper\API;
-	class Attachment {
-		public $content;
-		public $contentId;
-		public $contenType;
-		public $filename;
-	}
-	
+
+class Attachment
+{
+    public $content;
+    public $contentId;
+    public $contentType;
+    public $filename;
+}
+
 ?>


### PR DESCRIPTION
Fix typo "contenType" so sending e-mails with attachments no longer throw:

`{
  "allErrors": [
    {
      "code": null,
      "arguments": null,
      "defaultMessage": "Unknown error in field: attachments[0].contenType",
      "objectName": null,
      "field": "attachments[0].contenType",
      "rejectedValue": null
    }
  ]
}
`