### PR TITLE
Add missing use statements

### DIFF
--- a/Plugin/TransportPlugin.php
+++ b/Plugin/TransportPlugin.php
@@ -8,6 +8,8 @@ use Magento\Framework\Mail\TransportInterface;
 use Magento\Framework\Encryption\EncryptorInterface;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Module\Manager;
+use Magento\Framework\Exception\MailException;
+use Magento\Framework\Phrase;
 
 use Flowmailer\M2Connector\Registry\MessageData;
 


### PR DESCRIPTION
When a api call returns anything other than a 200 OK response, the Transport plugin can't autoload  MailException and Phrase because of missing use-statements