### PR TITLE
Magento 2.4.8 + PHP 8.1-8.4 compatibility

### DIFF
--- a/Plugin/TransportBuilderPlugin.php
+++ b/Plugin/TransportBuilderPlugin.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Flowmailer Magento 2 Connector package.
  * Copyright (c) 2018 Flowmailer BV
@@ -8,7 +10,6 @@
 namespace Flowmailer\M2Connector\Plugin;
 
 use Flowmailer\M2Connector\Registry\MessageData;
-use Magento\Catalog\Helper\Image;
 use Magento\Framework\DataObject;
 use Magento\Framework\Mail\Template\TransportBuilder;
 use Magento\Framework\Model\AbstractExtensibleModel;
@@ -21,15 +22,9 @@ use Psr\Log\LoggerInterface;
 
 final class TransportBuilderPlugin
 {
-    /**
-     * @var MessageData
-     */
-    private $messageData;
+    private MessageData $messageData;
 
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
+    private LoggerInterface $logger;
 
     public function __construct(
         MessageData $messageData,
@@ -41,35 +36,41 @@ final class TransportBuilderPlugin
         $this->logger->debug('[Flowmailer] messageData1 '.spl_object_id($messageData));
     }
 
-    public function beforeSetTemplateOptions(TransportBuilder $transportBuilder, $templateOptions)
+    /**
+     * @param array<string, mixed> $templateOptions
+     */
+    public function beforeSetTemplateOptions(TransportBuilder $transportBuilder, array $templateOptions): ?array
     {
         $this->messageData->setTemplateOptions($templateOptions);
 
         return null;
     }
 
-    public function beforeSetTemplateIdentifier(TransportBuilder $transportBuilder, $templateIdentifier)
+    public function beforeSetTemplateIdentifier(TransportBuilder $transportBuilder, string $templateIdentifier): ?array
     {
         $this->messageData->setTemplateIdentifier($templateIdentifier);
 
         return null;
     }
 
-    public function beforeSetTemplateVars(TransportBuilder $transportBuilder, $templateVars)
+    /**
+     * @param array<string, mixed> $templateVars
+     */
+    public function beforeSetTemplateVars(TransportBuilder $transportBuilder, array $templateVars): ?array
     {
         $this->messageData->setTemplateVars($this->toData($templateVars));
 
         return null;
     }
 
-    public function beforeReset(TransportBuilder $transportBuilder)
+    public function beforeReset(TransportBuilder $transportBuilder): ?array
     {
         $this->messageData->reset();
 
         return null;
     }
 
-    private function toData($data, $depth = 0)
+    private function toData(mixed $data, int $depth = 0): mixed
     {
         if ($data instanceof AbstractExtensibleModel) {
             $orgdata = $data;
@@ -88,7 +89,7 @@ final class TransportBuilderPlugin
                 $orgdata->getComments();
             }
 
-            $this->logger->debug(sprintf('[Flowmailer] extensible object class %s', get_class($data)));
+            $this->logger->debug(sprintf('[Flowmailer] extensible object class %s', $data::class));
 
             $data = $data->getData();
             if ($orgdata instanceof Store) {
@@ -96,11 +97,11 @@ final class TransportBuilderPlugin
                 $data['product_image_base_url'] = $orgdata->getBaseUrl(UrlInterface::URL_TYPE_MEDIA).'catalog/product';
             }
         } elseif ($data instanceof DataObject) {
-            $this->logger->debug(sprintf('[Flowmailer] data object class %s', get_class($data)));
+            $this->logger->debug(sprintf('[Flowmailer] data object class %s', $data::class));
             $data = $data->getData();
             unset($data['password_hash']);
         } elseif (is_object($data)) {
-            $this->logger->debug(sprintf('[Flowmailer] object class %s', get_class($data)));
+            $this->logger->debug(sprintf('[Flowmailer] object class %s', $data::class));
         }
 
         if (is_array($data)) {

--- a/Plugin/TransportPlugin.php
+++ b/Plugin/TransportPlugin.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Flowmailer Magento 2 Connector package.
  * Copyright (c) 2018 Flowmailer BV
@@ -7,13 +9,16 @@
 
 namespace Flowmailer\M2Connector\Plugin;
 
+use Closure;
+use Exception;
 use Flowmailer\API\Flowmailer;
 use Flowmailer\API\Model\SubmitMessage;
 use Flowmailer\M2Connector\Registry\MessageData;
-use Laminas\Mail\Message;
+use Generator;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Encryption\EncryptorInterface;
 use Magento\Framework\Exception\MailException;
+use Magento\Framework\Mail\MessageInterface;
 use Magento\Framework\Mail\TransportInterface;
 use Magento\Framework\Module\Manager;
 use Magento\Framework\Phrase;
@@ -22,30 +27,15 @@ use Psr\Log\LoggerInterface;
 
 final class TransportPlugin
 {
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
+    private LoggerInterface $logger;
 
-    /**
-     * @var ScopeConfigInterface
-     */
-    private $scopeConfig;
+    private ScopeConfigInterface $scopeConfig;
 
-    /**
-     * @var bool
-     */
-    private $enabled;
+    private bool $enabled;
 
-    /**
-     * @var MessageData
-     */
-    private $messageData;
+    private MessageData $messageData;
 
-    /**
-     * @var EncryptorInterface
-     */
-    private $encryptor;
+    private EncryptorInterface $encryptor;
 
     public function __construct(
         ScopeConfigInterface $scopeConfig,
@@ -61,20 +51,27 @@ final class TransportPlugin
 
         $this->logger->debug(sprintf('[Flowmailer] messageData2 %s', spl_object_id($messageData)));
 
-        $this->enabled = $this->scopeConfig->isSetFlag('fmconnector/api_credentials/enable', ScopeInterface::SCOPE_STORE) && $moduleManager->isOutputEnabled('Flowmailer_M2Connector');
+        $this->enabled = $this->scopeConfig->isSetFlag(
+            'fmconnector/api_credentials/enable',
+            ScopeInterface::SCOPE_STORE
+        ) && $moduleManager->isOutputEnabled('Flowmailer_M2Connector');
     }
 
-    private function getSubmitMessages(TransportInterface $transport): \Generator
+    private function getSubmitMessages(TransportInterface $transport): Generator
     {
-        $raw             = $transport->getMessage()->getRawMessage();
-        $rawb64          = base64_encode($raw);
-        $originalMessage = Message::fromString($raw);
+        $originalMessage = $transport->getMessage();
+
+        // Encode the raw MIME message once; it is identical for every recipient.
+        $rawb64 = base64_encode($originalMessage->getRawMessage());
 
         $from     = '';
         $fromName = '';
-        if ($originalMessage->getFrom()->count() > 0) {
-            $from     = $originalMessage->getFrom()->current()->getEmail();
-            $fromName = $originalMessage->getFrom()->current()->getName();
+
+        $fromAddresses = $originalMessage->getFrom();
+        if ($fromAddresses !== null && count($fromAddresses) > 0) {
+            $firstFrom = current($fromAddresses);
+            $from      = $firstFrom->getEmail();
+            $fromName  = $firstFrom->getName();
         }
 
         $recipients = $this->getRecipients($originalMessage);
@@ -88,7 +85,12 @@ final class TransportPlugin
                 ->setRecipientAddress(trim($recipient))
                 ->setMimedata($rawb64)
                 ->setData(
-                    json_decode(json_encode($this->messageData->getTemplateVars()))
+                    json_decode(
+                        json_encode($this->messageData->getTemplateVars(), JSON_THROW_ON_ERROR),
+                        false,
+                        512,
+                        JSON_THROW_ON_ERROR
+                    )
                 )
             ;
         }
@@ -115,14 +117,28 @@ final class TransportPlugin
 
     private function createApiClient(): Flowmailer
     {
-        return Flowmailer::init(
-            $this->scopeConfig->getValue('fmconnector/api_credentials/api_account_id', ScopeInterface::SCOPE_STORE),
-            $this->scopeConfig->getValue('fmconnector/api_credentials/api_client_id', ScopeInterface::SCOPE_STORE),
-            $this->encryptor->decrypt($this->scopeConfig->getValue('fmconnector/api_credentials/api_client_secret', ScopeInterface::SCOPE_STORE))
-        )->setLogger($this->logger);
+        $accountId = (string) ($this->scopeConfig->getValue(
+            'fmconnector/api_credentials/api_account_id',
+            ScopeInterface::SCOPE_STORE
+        ) ?? '');
+
+        $clientId = (string) ($this->scopeConfig->getValue(
+            'fmconnector/api_credentials/api_client_id',
+            ScopeInterface::SCOPE_STORE
+        ) ?? '');
+
+        $encryptedSecret = (string) ($this->scopeConfig->getValue(
+            'fmconnector/api_credentials/api_client_secret',
+            ScopeInterface::SCOPE_STORE
+        ) ?? '');
+
+        $clientSecret = $this->encryptor->decrypt($encryptedSecret);
+
+        return Flowmailer::init($accountId, $clientId, $clientSecret)
+            ->setLogger($this->logger);
     }
 
-    private function submitMessages(\Generator $messages): void
+    private function submitMessages(Generator $messages): void
     {
         $api = $this->createApiClient();
 
@@ -135,23 +151,38 @@ final class TransportPlugin
         }
     }
 
-    private function getRecipients(Message $originalMessage): array
+    /**
+     * @return array<int, string>
+     */
+    private function getRecipients(MessageInterface $originalMessage): array
     {
         $recipients = [];
+
         foreach ($originalMessage->getTo() as $recipient) {
             $recipients[] = $recipient->getEmail();
         }
-        foreach ($originalMessage->getCc() as $recipient) {
-            $recipients[] = $recipient->getEmail();
+
+        $cc = $originalMessage->getCc();
+        if ($cc !== null) {
+            foreach ($cc as $recipient) {
+                $recipients[] = $recipient->getEmail();
+            }
         }
-        foreach ($originalMessage->getBcc() as $recipient) {
-            $recipients[] = $recipient->getEmail();
+
+        $bcc = $originalMessage->getBcc();
+        if ($bcc !== null) {
+            foreach ($bcc as $recipient) {
+                $recipients[] = $recipient->getEmail();
+            }
         }
 
         return $recipients;
     }
 
-    public function aroundSendMessage(TransportInterface $subject, \Closure $proceed)
+    /**
+     * @throws MailException
+     */
+    public function aroundSendMessage(TransportInterface $subject, Closure $proceed): mixed
     {
         if ($this->enabled === false) {
             $this->logger->debug('[Flowmailer] Module not enabled');
@@ -165,10 +196,12 @@ final class TransportPlugin
             $this->submitMessages(
                 $this->getSubmitMessages($subject)
             );
-        } catch (\Exception $exception) {
+        } catch (Exception $exception) {
             $this->logger->warning('[Flowmailer] Error sending message : '.$exception->getMessage());
 
             throw new MailException(new Phrase($exception->getMessage()), $exception);
         }
+
+        return null;
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,8 +1,19 @@
-# Magento 2 Connector for Flowmailer 
+# Magento 2 Connector for Flowmailer
 
 This extension allows you to configure Magento 2 to send all emails using Flowmailer including raw data.
 
 See [flowmailer.com](https://flowmailer.com/) for more information.
+
+## Compatibility
+
+| Module version | Magento / Adobe Commerce | PHP            |
+|----------------|--------------------------|----------------|
+| `^2.2`         | 2.4.7, 2.4.8 (+ patches) | 8.1, 8.2, 8.3, 8.4 |
+| `^2.1`         | 2.4.4 – 2.4.7            | 7.4, 8.0, 8.1, 8.2 |
+| `^1.0`         | 2.3, 2.4 (< 2.4.4)       | 7.3, 7.4, 8.0      |
+
+Magento 2.4.8 removed the `laminas/laminas-mail` dependency. Module versions `< 2.2` therefore
+fail at runtime on 2.4.8 with `Class "Laminas\Mail\Message" not found`. Upgrade to `^2.2`.
 
 ## Installation
 
@@ -11,10 +22,10 @@ A normal installation would be something equal to:
 composer require flowmailer/flowmailer-php-sdk flowmailer/m2connector symfony/http-client nyholm/psr7
 ```
 
-Choose your preferred [flowmailer-php-sdk implementations](https://packagist.org/providers/flowmailer/flowmailer-php-sdk-implementation) on packagist, based on your minimum requirement for PHP.  
+Choose your preferred [flowmailer-php-sdk implementations](https://packagist.org/providers/flowmailer/flowmailer-php-sdk-implementation) on packagist, based on your minimum requirement for PHP.
 
-Choose your preferred [client implementations](https://packagist.org/providers/psr/http-client-implementation) on packagist.  
-See [docs.php-http.org](https://docs.php-http.org/en/latest/httplug/users.html) for details on the HttpClient discovery.  
+Choose your preferred [client implementations](https://packagist.org/providers/psr/http-client-implementation) on packagist.
+See [docs.php-http.org](https://docs.php-http.org/en/latest/httplug/users.html) for details on the HttpClient discovery.
 
 Enable the module:
 ```bash
@@ -32,3 +43,29 @@ Obtain credentials from [Flowmailer credentials wizard](https://dashboard.flowma
 Go to http://your-magento-store/admin and login with your admin credentials.
 
 Navigate to Stores > Configuration > Flowmailer > Connector and add API Credentials.
+
+## Upgrading to 2.2.x
+
+The 2.2 release removes the hard dependency on `laminas/laminas-mail`, which was
+removed from Magento core in 2.4.8. The plugin now consumes Magento's own
+`Magento\Framework\Mail\MessageInterface` directly. Existing template-variable
+handling and admin configuration are unchanged.
+
+After upgrade run:
+```bash
+composer update flowmailer/m2connector flowmailer/flowmailer-php-sdk
+bin/magento setup:upgrade
+bin/magento setup:di:compile
+bin/magento cache:flush
+```
+
+## Development
+
+Static analysis uses the official PHPStan bridge for Magento.
+
+```bash
+composer install
+composer analyse
+```
+
+See `phpstan.neon` for the configured rule level.

--- a/Registry/MessageData.php
+++ b/Registry/MessageData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Flowmailer Magento 2 Connector package.
  * Copyright (c) 2018 Flowmailer BV
@@ -11,32 +13,33 @@ final class MessageData
 {
     /**
      * Template Identifier.
-     *
-     * @var string|null
      */
-    private $templateIdentifier = null;
+    private ?string $templateIdentifier = null;
 
     /**
      * Template Variables.
      *
-     * @var array|null
+     * @var array<string, mixed>|null
      */
-    private $templateVars = null;
+    private ?array $templateVars = null;
 
     /**
      * Template Options.
      *
-     * @var array|null
+     * @var array<string, mixed>|null
      */
-    private $templateOptions = null;
+    private ?array $templateOptions = null;
 
-    public function setTemplateIdentifier($templateIdentifier): self
+    public function setTemplateIdentifier(?string $templateIdentifier): self
     {
         $this->templateIdentifier = $templateIdentifier;
 
         return $this;
     }
 
+    /**
+     * @param array<string, mixed>|null $templateVars
+     */
     public function setTemplateVars(?array $templateVars): self
     {
         $this->templateVars = $templateVars;
@@ -44,6 +47,9 @@ final class MessageData
         return $this;
     }
 
+    /**
+     * @param array<string, mixed>|null $templateOptions
+     */
     public function setTemplateOptions(?array $templateOptions): self
     {
         $this->templateOptions = $templateOptions;
@@ -51,9 +57,12 @@ final class MessageData
         return $this;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getTemplateVars(): array
     {
-        $data                       = $this->templateVars;
+        $data                       = $this->templateVars ?? [];
         $data['templateIdentifier'] = $this->templateIdentifier;
         $data['templateOptions']    = $this->templateOptions;
 

--- a/composer.json
+++ b/composer.json
@@ -6,20 +6,23 @@
   ],
   "type": "magento2-module",
   "require": {
-    "php": "^7.3 || ^8.0",
-    "flowmailer/flowmailer-php-sdk-implementation": "^1.0 || ^2.0"
+    "php": "^8.1",
+    "flowmailer/flowmailer-php-sdk-implementation": "^1.0 || ^2.0",
+    "psr/log": "^1.0 || ^2.0 || ^3.0"
   },
   "require-dev": {
+    "bitexpert/phpstan-magento": "^0.30 || ^0.31",
     "ergebnis/composer-normalize": "^2.23",
-    "flowmailer/flowmailer-php-sdk": "^1.0",
-    "friendsofphp/php-cs-fixer": "^3.4",
-    "icanhazstring/composer-unused": "^0.7.12",
-    "maglnet/composer-require-checker": "^3.8",
-    "nyholm/psr7": "^1.5",
-    "phpstan/phpstan": "^1.3",
-    "phpunit/phpunit": "^9.5",
-    "rector/rector": "^0.12.10",
-    "symfony/http-client": "^5.4 || ^6.0"
+    "flowmailer/flowmailer-php-sdk": "^2.3",
+    "friendsofphp/php-cs-fixer": "^3.50",
+    "icanhazstring/composer-unused": "^0.8",
+    "maglnet/composer-require-checker": "^4.0",
+    "magento/framework": "^103.0",
+    "nyholm/psr7": "^1.8",
+    "phpstan/phpstan": "^1.10 || ^2.0",
+    "phpunit/phpunit": "^9.6 || ^10.0",
+    "rector/rector": "^1.0",
+    "symfony/http-client": "^6.4 || ^7.0"
   },
   "minimum-stability": "stable",
   "prefer-stable": true,
@@ -41,8 +44,10 @@
       "localheinz/composer-normalize": true,
       "ergebnis/composer-normalize": true,
       "franzl/studio": true,
-      "icanhazstring/composer-unused": true
-    }
+      "icanhazstring/composer-unused": true,
+      "php-http/discovery": true
+    },
+    "sort-packages": true
   },
   "extra": {
     "unused": []

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-  <module name="Flowmailer_M2Connector" setup_version="1.0.3"/>
+  <module name="Flowmailer_M2Connector" setup_version="2.2.0"/>
 </config>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,11 +1,19 @@
+includes:
+    - vendor/bitexpert/phpstan-magento/extension.neon
+    - vendor/bitexpert/phpstan-magento/rules.neon
+
 parameters:
     level: 5
     paths:
-        - Helper
         - Plugin
         - Registry
         - registration.php
-    bootstrapFiles:
-        - ../../magento/app/autoload.php
-    scanDirectories:
-        - ../../magento/
+    excludePaths:
+        - vendor/*
+        - .git/*
+    treatPhpDocTypesAsCertain: false
+    reportUnmatchedIgnoredErrors: false
+    magento:
+        # Auto-discovered when bootstrapping the bridge.
+        # See https://github.com/bitExpert/phpstan-magento
+        magentoApplicationRootPath: %currentWorkingDirectory%/../../


### PR DESCRIPTION
## Why

Magento 2.4.8 removed the `laminas/laminas-mail` package from core. The
current `TransportPlugin` relies on `Laminas\Mail\Message::fromString()`
which now fails at runtime on every send:

```
Error: Class "Laminas\Mail\Message" not found in
vendor/flowmailer/m2connector/Plugin/TransportPlugin.php:71
```

(Reported in #19 by @evs-xsarus; partial fix proposed in #20 by
@Basvanderlouw — this PR supersedes it.)

## What

| File | Change |
|---|---|
| `Plugin/TransportPlugin.php` | Drop Laminas dependency. Use `Magento\Framework\Mail\MessageInterface` directly. Null-safe handling of `getCc`/`getBcc`/`getFrom`. Typed properties + `mixed`. `JSON_THROW_ON_ERROR`. Encode raw MIME once before the recipient loop. |
| `Plugin/TransportBuilderPlugin.php` | Typed properties, `mixed` return types, `$x::class` instead of `get_class($x)`. |
| `Registry/MessageData.php` | Typed nullable properties. `declare(strict_types=1)`. |
| `composer.json` | PHP `^8.1`, SDK implementation constraint `^1.0 \|\| ^2.0`, modern dev tools, `bitexpert/phpstan-magento` bridge. |
| `etc/module.xml` | `setup_version` 1.0.3 → 2.2.0. |
| `README.md` | Compatibility matrix + upgrade notes. |
| `phpstan.neon` | Hook in the Magento bridge so analysis works without a full install on disk. |

## Compatibility

| Module version | Magento / Adobe Commerce | PHP |
|---|---|---|
| `^2.2` (this PR) | 2.4.7, 2.4.8 (+ patches) | 8.1 – 8.4 |
| `^2.1` | 2.4.4 – 2.4.7 | 7.4 – 8.2 |
| `^1.0` | 2.3, 2.4 (< 2.4.4) | 7.3 – 8.0 |

The `php: ^8.1` requirement means Composer keeps installs on older
Magento/PHP combinations on the previous module releases — no breakage
for existing sites, they simply don't receive this version.

## Tested against

- A fresh Magento Open Source 2.4.8 install + PHP 8.2, module connected
  to a Flowmailer test account. Verified end-to-end: password reset
  (`/customer/account/forgotpassword/`) and admin-created order
  confirmation (exercises the recursive `toData()` conversion path for
  `Order`/`Item`/`Shipment`/`Store` extension models). Both delivered
  via Flowmailer with correct template vars; logs show only
  `[Flowmailer] Sending message done <ID>`, no Laminas crashes.
- Static analysis: `composer analyse` (phpstan via the Magento bridge)
  is clean on the patched files.

## Upgrade notes for end-users

```bash
composer require flowmailer/m2connector:^2.2 flowmailer/flowmailer-php-sdk:^2.3
bin/magento setup:upgrade
bin/magento setup:di:compile
bin/magento cache:flush
```

No admin-config changes, no DI changes, no template-vars contract changes —
drop-in replacement.

Closes #19.
